### PR TITLE
README.md: Wrap argument list in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,21 +99,21 @@ jobs:
           # Additional arguments can be appended to the cmake command.
           # This is useful to reduce the number of CMake's Presets since you can reuse
           # an existing preset with different variables.
-          configurePresetAdditionalArgs: ['-DENABLE_YOUR_FEATURE=1']
+          configurePresetAdditionalArgs: "['-DENABLE_YOUR_FEATURE=1']"
 
           # This is the name of the CMakePresets.json's configuration to build the project.
           buildPreset: 'ninja-multi-vcpkg'
           # Additional arguments can be appended when building, for example to specify the
           # configuration to build.
           # This is useful to reduce the number of CMake's Presets you need in CMakePresets.json.
-          buildPresetAdditionalArgs: ['--config Release']
+          buildPresetAdditionalArgs: "['--config Release']"
     
           # This is the name of the CMakePresets.json's configuration to test the project with.
           testPreset: 'ninja-multi-vcpkg'
           # Additional arguments can be appended when testing, for example to specify the config
           # to test.
           # This is useful to reduce the number of CMake's Presets you need in CMakePresets.json.
-          testPresetAdditionalArgs: ['--config Release']
+          testPresetAdditionalArgs: "['--config Release']"
 
     #env:
     #  VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }} # [OPTIONAL] Define the vcpkg's triplet 


### PR DESCRIPTION
Otherwise the workflow is rejected with the following error:

`A sequence was not expected`

---

Related: SamKirkland/FTP-Deploy-Action#202