### PR TITLE
feat: Set parallelization level

### DIFF
--- a/src/cmake-action.ts
+++ b/src/cmake-action.ts
@@ -7,6 +7,8 @@ import * as runcmakelib from '@lukka/run-cmake-lib'
 import * as cmakeglobals from '@lukka/run-cmake-lib/build/cmake-globals'
 import * as vcpkgglobals from '@lukka/run-cmake-lib/build/vcpkg-globals'
 import * as core from '@actions/core'
+import * as process from "process"
+import * as os from "os"
 
 export async function main(): Promise<void> {
   const actionLib: libaction.ActionLib = new libaction.ActionLib();
@@ -26,6 +28,12 @@ export async function main(): Promise<void> {
     const testPresetAdditionalArgs = actionLib.getInput(cmakeglobals.testPresetAdditionalArgs, false);
     const packagePresetAdditionalArgs = actionLib.getInput(cmakeglobals.packagePresetAdditionalArgs, false);
     const runVcpkgEnvFormatString = actionLib.getInput(vcpkgglobals.runVcpkgEnvFormatStringInput, false);
+
+    // Set parallelization level
+    const nproc = os.availableParallelism();
+    process.env["CMAKE_BUILD_PARALLEL_LEVEL"] = `${nproc}`;
+    process.env["CTEST_PARALLEL_LEVEL"] = `${nproc}`;
+
     await runcmakelib.CMakeRunner.run(
       actionLib,
       workflowPreset, workflowPresetCmdStringFormat,


### PR DESCRIPTION
I couldn't execute `npm install` so I have to rely on the CI to produce the dist-git

```
/usr/bin/npm install
npm ERR! code E401
npm ERR! 401 Unauthorized - GET https://npm.pkg.github.com/download/@lukka/run-vcpkg-lib/3.9.4/2ac5f82de33b196e62077d4f2218273d09b3b8a2 - authentication token not provided

npm ERR! A complete log of this run can be found in: /home/lecris/.npm/_logs/2023-11-29T12_31_49_400Z-debug-0.log
```

Question is, do you want it in here or in `@lukka/run-cmake-lib`? The only thing that is unclear is that the GH-Action variables would be in this repo, so how do you want to interface with the library to set it?

TODO:
- [ ] Write test. Could use [`ProcessorCount`](https://cmake.org/cmake/help/latest/module/ProcessorCount.html) to check what CMake detects it has, and then compare with the verbose call, to see what `-J` variable was set
- [ ] Write GH-Action interface to overwrite the behavior